### PR TITLE
Fix recursion when empty filter added.

### DIFF
--- a/mongo_filter_evaluator/base.py
+++ b/mongo_filter_evaluator/base.py
@@ -23,7 +23,7 @@ class BaseConditionEvaluator(object):
         raise NotImplementedError('Error :(')
 
     def evaluate(self, condition=None):
-        condition = condition if condition else self.condition
+        condition = condition if condition is not None else self.condition
         return self.evaluate_logic('$and', condition)
 
     def evaluate_condition(self, keyword, body):

--- a/tests/test_mongo_filter_evaluator.py
+++ b/tests/test_mongo_filter_evaluator.py
@@ -30,6 +30,20 @@ def test_validate():
     }).validate()) == 2
 
 
+def test_evaluate_emptyfilter():
+    assert DataConditionEvaluator(
+        {
+            "$and": [
+               {'value': 'value'},
+               {}
+            ]
+        },
+        {
+            'value': 'value',
+            'int': 1
+        }
+    ).evaluate()
+
 def test_evaluate():
     assert DataConditionEvaluator(
         {


### PR DESCRIPTION
The current code incorrectly resets the filter when {} is passed as the condition. This leads to infinite recursive call when evaluating the filter.
